### PR TITLE
zpl_printf doesn't support %0d correctly

### DIFF
--- a/code/apps/examples/print_extensions.c
+++ b/code/apps/examples/print_extensions.c
@@ -4,7 +4,6 @@
 
 int main(void)
 {
-    int number = 32;
     zpl_printf("0.%0d%d\n", 0, 32);
     zpl_printf("0.%*d%d\n", 0, 42, 32);
     zpl_printf("0.%*d%d\n", 42, 0, 32);

--- a/code/apps/examples/print_extensions.c
+++ b/code/apps/examples/print_extensions.c
@@ -1,0 +1,13 @@
+#define ZPL_IMPLEMENTATION
+#define ZPL_NANO
+#include "zpl.h"
+
+int main(void)
+{
+    int number = 32;
+    zpl_printf("0.%0d%d\n", 0, 32);
+    zpl_printf("0.%*d%d\n", 0, 42, 32);
+    zpl_printf("0.%*d%d\n", 42, 0, 32);
+    zpl_printf("0.%0*d%d\n", 42, 0, 32);
+    return 0;
+}

--- a/code/source/core/print.c
+++ b/code/source/core/print.c
@@ -269,7 +269,7 @@ ZPL_NEVER_INLINE zpl_isize zpl_snprintf_va(char *text, zpl_isize max_len, char c
                 case '+': {info.flags |= ZPL_FMT_PLUS; break;}
                 case '#': {info.flags |= ZPL_FMT_ALT; break;}
                 case ' ': {info.flags |= ZPL_FMT_SPACE; break;}
-                case '0': {info.flags |= ZPL_FMT_ZERO; info.flags |= ZPL_FMT_WIDTH; break;}
+                case '0': {info.flags |= (ZPL_FMT_ZERO|ZPL_FMT_WIDTH); break;}
                 default: {info.flags |= ZPL_FMT_DONE; break;}
                 }
             } while (!(info.flags & ZPL_FMT_DONE));

--- a/code/zpl.h
+++ b/code/zpl.h
@@ -27,6 +27,7 @@ GitHub:
   https://github.com/zpl-c/zpl
 
 Version History:
+  10.0.6 - Fix zpl_printf "%0d" format specifier
   10.0.4 - Flush tester output to fix ordering
   10.0.3 - Fix ZPL_STATIC_ASSERT under MSVC
   10.0.0 - Major overhaul of the library

--- a/code/zpl.h
+++ b/code/zpl.h
@@ -246,7 +246,7 @@ Version History:
 
 #define ZPL_VERSION_MAJOR 10
 #define ZPL_VERSION_MINOR 0
-#define ZPL_VERSION_PATCH 6
+#define ZPL_VERSION_PATCH 7
 #define ZPL_VERSION_PRE ""
 
 #include "zpl_hedley.h"

--- a/code/zpl.h
+++ b/code/zpl.h
@@ -27,7 +27,7 @@ GitHub:
   https://github.com/zpl-c/zpl
 
 Version History:
-  10.0.6 - Fix zpl_printf "%0d" format specifier
+  10.0.8 - Fix zpl_printf "%0d" format specifier
   10.0.4 - Flush tester output to fix ordering
   10.0.3 - Fix ZPL_STATIC_ASSERT under MSVC
   10.0.0 - Major overhaul of the library

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zpl.c",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "homepage": "https://github.com/zpl-c/zpl#readme",
   "description": "Single-file header-only C and C++ helper library.",
   "author": "Dominik Madarasz <zaklaus@outlook.com> (http://madaraszd.net/)",


### PR DESCRIPTION
We now assign a flag which tells us whether a width has been specified, so that a width of 0 is also respected appropriately.