### PR TITLE
ZPL_PLATFORM_CYGWIN

### DIFF
--- a/code/header/core/debug.h
+++ b/code/header/core/debug.h
@@ -20,6 +20,7 @@ ZPL_BEGIN_C_DECLS
 #endif
 
 #ifndef ZPL_ASSERT_MSG
+    #if defined(_MSC_VER)
     #define ZPL_ASSERT_MSG(cond, msg, ...)                                                                             \
     do {                                                                                                               \
         if (!(cond)) {                                                                                                 \
@@ -27,6 +28,14 @@ ZPL_BEGIN_C_DECLS
             ZPL_DEBUG_TRAP( );                                                                                         \
         }                                                                                                              \
     } while (0)
+    #else
+    #define ZPL_ASSERT_MSG(cond, msg, ...)                                                                             \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            ZPL_DEBUG_TRAP( );                                                                                         \
+        }                                                                                                              \
+    } while (0)
+    #endif
 #endif
 
 #ifndef ZPL_ASSERT

--- a/code/header/core/debug.h
+++ b/code/header/core/debug.h
@@ -20,7 +20,6 @@ ZPL_BEGIN_C_DECLS
 #endif
 
 #ifndef ZPL_ASSERT_MSG
-    #if defined(_MSC_VER)
     #define ZPL_ASSERT_MSG(cond, msg, ...)                                                                             \
     do {                                                                                                               \
         if (!(cond)) {                                                                                                 \
@@ -28,14 +27,6 @@ ZPL_BEGIN_C_DECLS
             ZPL_DEBUG_TRAP( );                                                                                         \
         }                                                                                                              \
     } while (0)
-    #else
-    #define ZPL_ASSERT_MSG(cond, msg, ...)                                                                             \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            ZPL_DEBUG_TRAP( );                                                                                         \
-        }                                                                                                              \
-    } while (0)
-    #endif
 #endif
 
 #ifndef ZPL_ASSERT

--- a/code/header/core/system.h
+++ b/code/header/core/system.h
@@ -69,6 +69,10 @@ defined(__ppc64__) || defined(__aarch64__)
         #ifndef ZPL_SYSTEM_EMSCRIPTEN
             #define ZPL_SYSTEM_EMSCRIPTEN 1
         #endif
+    #elif defined(__CYGWIN__)
+        #ifndef ZPL_SYSTEM_CYGWIN
+            #define ZPL_SYSTEM_CYGWIN 1
+        #endif
     #else
         #error This UNIX operating system is not supported
     #endif

--- a/code/header/threading/affinity.h
+++ b/code/header/threading/affinity.h
@@ -6,7 +6,7 @@
 
 ZPL_BEGIN_C_DECLS
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined (ZPL_SYSTEM_CYGWIN)
 
     typedef struct zpl_affinity {
         zpl_b32   is_accurate;

--- a/code/source/core/file.c
+++ b/code/source/core/file.c
@@ -297,7 +297,7 @@ zpl_b32 zpl_file_has_changed(zpl_file *f) {
 zpl_global zpl_b32 zpl__std_file_set = false;
 zpl_global zpl_file zpl__std_files[ZPL_FILE_STANDARD_COUNT] = { { 0 } };
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
 
 zpl_file *zpl_file_get_standard(zpl_file_standard_type std) {
     if (!zpl__std_file_set) {

--- a/code/source/core/file.c
+++ b/code/source/core/file.c
@@ -15,9 +15,13 @@
     #include <copyfile.h>
 #endif
 
+#ifdef ZPL_SYSTEM_CYGWIN
+#   include <windows.h>
+#endif
+
 ZPL_BEGIN_C_DECLS
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined (ZPL_SYSTEM_CYGWIN)
 
     zpl_internal wchar_t *zpl__alloc_utf8_to_ucs2(zpl_allocator a, char const *text, zpl_isize *w_len_) {
         wchar_t *w_text = NULL;
@@ -234,7 +238,7 @@ zpl_file_error zpl_file_open_mode(zpl_file *f, zpl_file_mode mode, char const *f
     zpl_file file_ = {0};
     *f = file_;
     zpl_file_error err;
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
     err = zpl__win32_file_open(&f->fd, &f->ops, mode, filename);
 #else
     err = zpl__posix_file_open(&f->fd, &f->ops, mode, filename);

--- a/code/source/core/filesystem.c
+++ b/code/source/core/filesystem.c
@@ -8,19 +8,25 @@
     #include <dirent.h>
 #endif
 
-#if defined(ZPL_SYSTEM_UNIX) && !defined(ZPL_SYSTEM_FREEBSD)
+#if defined(ZPL_SYSTEM_UNIX) && !defined(ZPL_SYSTEM_FREEBSD) && !defined(ZPL_SYSTEM_CYGWIN)
     #include <sys/sendfile.h>
 #endif
 
-#if defined(ZPL_SYSTEM_WINDOWS)
-    #include <io.h>
-    #include <direct.h>
+#if defined(ZPL_SYSTEM_WINDOWS) 
+#   include <io.h>
+#   include <direct.h>
+#endif
+
+#if defined(ZPL_SYSTEM_CYGWIN) 
+#   include <io.h>
+#   include <dirent.h>
+#   include <windows.h>
 #endif
 
 ZPL_BEGIN_C_DECLS
 
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
     zpl_file_time zpl_fs_last_write_time(char const *filepath) {
         ULARGE_INTEGER li = { 0 };
         FILETIME last_write_time = { 0 };

--- a/code/source/core/filesystem.c
+++ b/code/source/core/filesystem.c
@@ -160,7 +160,7 @@ char *zpl_path_get_full_name(zpl_allocator a, char const *path) {
         return NULL;
     }
 
-    new_path = zpl_alloc_array(a, char, new_len1);
+    new_path = zpl_alloc_array(a, char, new_len);
     new_len1 = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, w_fullpath, cast(int) w_len, new_path,
                                    cast(int) new_len, NULL, NULL);
 

--- a/code/source/core/time.c
+++ b/code/source/core/time.c
@@ -86,7 +86,7 @@ ZPL_BEGIN_C_DECLS
     }
 #endif
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
 
     zpl_f64 zpl_time_now(void) {
         zpl_local_persist LARGE_INTEGER win32_perf_count_freq = { 0 };

--- a/code/source/threading/affinity.c
+++ b/code/source/threading/affinity.c
@@ -10,7 +10,7 @@
 
 ZPL_BEGIN_C_DECLS
 
-#if defined(ZPL_SYSTEM_WINDOWS)
+#if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
 
     void zpl_affinity_init(zpl_affinity *a) {
         SYSTEM_LOGICAL_PROCESSOR_INFORMATION *start_processor_info = NULL;


### PR DESCRIPTION
Compile for cygwin: `ZPL_PLATFORM_CYGWIN`.
Fixed a 0 sized array allocation.