### PR TITLE
docs: fix simple typo, parttern -> pattern

### DIFF
--- a/code/source/core/filesystem.c
+++ b/code/source/core/filesystem.c
@@ -288,7 +288,7 @@ void zpl__file_direntry(zpl_allocator alloc, char const *dirname, zpl_string *ou
     // remove trailing slashses
     if (directory[length - 1] == '\\') { directory[length - 1] = '\0'; }
 
-    // attach search parttern
+    // attach search pattern
     zpl_string findpath = zpl_string_make(alloc, directory);
     findpath = zpl_string_appendc(findpath, "\\");
     findpath = zpl_string_appendc(findpath, "*");


### PR DESCRIPTION
There is a small typo in code/source/core/filesystem.c.

Should read `pattern` rather than `parttern`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md