### PR TITLE
Time: Improve the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ int main(int argc, char **argv) {
     zpl_json_object root = {0};
 
     u8 err;
-    f64 time = zpl_time_now();
+    f64 time = zpl_time_rel();
     zpl_json_parse(&root, fc.size, (char *)fc.data, zpl_heap(), strip_comments, &err);
-    f64 delta = zpl_time_now() - time;
+    f64 delta = zpl_time_rel() - time;
 
     if (err == ZPL_JSON_ERROR_OBJECT_OR_SOURCE_WAS_NULL)
     {

--- a/code/apps/examples/jobs.c
+++ b/code/apps/examples/jobs.c
@@ -39,10 +39,10 @@ int main() {
     zpl_jobs_enqueue(&p, calc_nums, NULL);
     zpl_jobs_enqueue(&p, calc_nums, NULL);
 
-    zpl_f64 time=zpl_time_now();
+    zpl_f64 time=zpl_time_rel();
 
     for (;;) {
-        zpl_f64 now=zpl_time_now();
+        zpl_f64 now=zpl_time_rel();
         zpl_f64 dt =now-time;
         if (dt > TEST_ENQUEUE_JOB) {
             time=now;

--- a/code/apps/examples/json_benchmark.c
+++ b/code/apps/examples/json_benchmark.c
@@ -50,9 +50,9 @@ int main(int argc, char **argv) {
     zpl_json_object root = {0};
 
     zpl_u8 err;
-    zpl_f64 time = zpl_time_now();
+    zpl_f64 time = zpl_time_rel();
     zpl_json_parse(&root, fc.size, (char *)fc.data, zpl_heap(), strip_comments, &err);
-    zpl_f64 delta = zpl_time_now() - time;
+    zpl_f64 delta = zpl_time_rel() - time;
 
     if (err == ZPL_JSON_ERROR_OBJECT_OR_SOURCE_WAS_NULL)
     {

--- a/code/apps/examples/time.c
+++ b/code/apps/examples/time.c
@@ -8,17 +8,19 @@ void do_time(void) {
     zpl_u64 u1 = zpl_utc_time_now_ms();
     zpl_f64 u2 = zpl_utc_time_now();
     zpl_u64 unix_timestamp = zpl_win32_to_unix_epoch(u1);
+    zpl_u64 local_time = zpl_local_time_now_ms();
+    zpl_u64 local_unix_timestamp = zpl_win32_to_unix_epoch(local_time);
 
-    zpl_printf("Time: f64(%f) u64(%llu) utc_u64(%llu) utc_f64(%f) unix_u64(%llu)\n", a1, a2, u1, u2, unix_timestamp);
+    zpl_printf("Time: f64(%f) u64(%llu)\nutc_u64(%llu) utc_f64(%f)\nunix_u64(%llu)\nlocal(%llu) local_unix(%llu)\n", a1, a2, u1, u2, unix_timestamp, local_time, local_unix_timestamp);
 }
 
 int main() {
     zpl_time_now_ms();
-    zpl_sleep(1.534);
+    zpl_sleep(1.534f);
     do_time();
 
     while(1) {
-        zpl_sleep(1);
+        zpl_sleep(0.5f);
         do_time();
     }
     return 0;

--- a/code/apps/examples/time.c
+++ b/code/apps/examples/time.c
@@ -1,0 +1,25 @@
+#define ZPL_IMPL
+#define ZPL_NANO
+#include <zpl.h>
+
+void do_time(void) {
+    zpl_f64 a1 = zpl_time_now();
+    zpl_u64 a2 = zpl_time_now_ms();
+    zpl_u64 u1 = zpl_utc_time_now_ms();
+    zpl_f64 u2 = zpl_utc_time_now();
+    zpl_u64 unix_timestamp = zpl_win32_to_unix_epoch(u1);
+
+    zpl_printf("Time: f64(%f) u64(%llu) utc_u64(%llu) utc_f64(%f) unix_u64(%llu)\n", a1, a2, u1, u2, unix_timestamp);
+}
+
+int main() {
+    zpl_time_now_ms();
+    zpl_sleep(1.534);
+    do_time();
+
+    while(1) {
+        zpl_sleep(1);
+        do_time();
+    }
+    return 0;
+}

--- a/code/apps/examples/time.c
+++ b/code/apps/examples/time.c
@@ -3,19 +3,19 @@
 #include <zpl.h>
 
 void do_time(void) {
-    zpl_f64 a1 = zpl_time_now();
-    zpl_u64 a2 = zpl_time_now_ms();
-    zpl_u64 u1 = zpl_utc_time_now_ms();
-    zpl_f64 u2 = zpl_utc_time_now();
-    zpl_u64 unix_timestamp = zpl_win32_to_unix_epoch(u1);
-    zpl_u64 local_time = zpl_local_time_now_ms();
-    zpl_u64 local_unix_timestamp = zpl_win32_to_unix_epoch(local_time);
+    zpl_f64 a1 = zpl_time_rel();
+    zpl_u64 a2 = zpl_time_rel_ms();
+    zpl_u64 u1 = zpl_time_utc_ms();
+    zpl_f64 u2 = zpl_time_utc();
+    zpl_u64 unix_timestamp = zpl_time_win32_to_unix(u1);
+    zpl_u64 local_time = zpl_time_tz_ms();
+    zpl_u64 local_unix_timestamp = zpl_time_win32_to_unix(local_time);
 
     zpl_printf("Time: f64(%f) u64(%llu)\nutc_u64(%llu) utc_f64(%f)\nunix_u64(%llu)\nlocal(%llu) local_unix(%llu)\n", a1, a2, u1, u2, unix_timestamp, local_time, local_unix_timestamp);
 }
 
 int main() {
-    zpl_time_now_ms();
+    zpl_time_rel_ms();
     zpl_sleep(1.534f);
     do_time();
 

--- a/code/header/core/time.h
+++ b/code/header/core/time.h
@@ -19,28 +19,28 @@ ZPL_BEGIN_C_DECLS
 ZPL_DEF zpl_u64 zpl_rdtsc(void);
 
 //! Return relative time (in seconds) since the application start.
-ZPL_DEF zpl_f64 zpl_time_now(void);
+ZPL_DEF zpl_f64 zpl_time_rel(void);
 
 //! Return relative time since the application start.
-ZPL_DEF zpl_u64 zpl_time_now_ms(void);
+ZPL_DEF zpl_u64 zpl_time_rel_ms(void);
 
 //! Return time (in seconds) since 1601-01-01 UTC.
-ZPL_DEF zpl_f64 zpl_utc_time_now(void);
+ZPL_DEF zpl_f64 zpl_time_utc(void);
 
 //! Return time since 1601-01-01 UTC.
-ZPL_DEF zpl_u64 zpl_utc_time_now_ms(void);
+ZPL_DEF zpl_u64 zpl_time_utc_ms(void);
 
 //! Return local system time since 1601-01-01
-ZPL_DEF zpl_u64 zpl_local_time_now_ms(void);
+ZPL_DEF zpl_u64 zpl_time_tz_ms(void);
 
 //! Return local system time in seconds since 1601-01-01
-ZPL_DEF zpl_f64 zpl_local_time_now(void);
+ZPL_DEF zpl_f64 zpl_time_tz(void);
 
 //! Convert Win32 epoch (1601-01-01 UTC) to UNIX (1970-01-01 UTC)
-ZPL_DEF_INLINE zpl_u64 zpl_win32_to_unix_epoch(zpl_u64 ms);
+ZPL_DEF_INLINE zpl_u64 zpl_time_win32_to_unix(zpl_u64 ms);
 
 //! Convert UNIX (1970-01-01 UTC) to Win32 epoch (1601-01-01 UTC)
-ZPL_DEF_INLINE zpl_u64 zpl_unix_to_win32_epoch(zpl_u64 ms);
+ZPL_DEF_INLINE zpl_u64 zpl_time_unix_to_win32(zpl_u64 ms);
 
 //! Sleep for specified number of milliseconds.
 ZPL_DEF void zpl_sleep_ms(zpl_u32 ms);
@@ -48,20 +48,36 @@ ZPL_DEF void zpl_sleep_ms(zpl_u32 ms);
 //! Sleep for specified number of seconds.
 ZPL_DEF_INLINE void zpl_sleep(zpl_f32 s);
 
+// Deprecated methods
+ZPL_DEPRECATED_FOR(10.9.0, zpl_time_rel)
+ZPL_DEF_INLINE zpl_f64 zpl_time_now(void);
+
+ZPL_DEPRECATED_FOR(10.9.0, zpl_time_utc)
+ZPL_DEF_INLINE zpl_f64 zpl_utc_time_now(void);
+
+
 #ifndef ZPL__UNIX_TO_WIN32_EPOCH
 #define ZPL__UNIX_TO_WIN32_EPOCH 11644473600000ull
 #endif
 
-ZPL_IMPL_INLINE zpl_u64 zpl_win32_to_unix_epoch(zpl_u64 ms) {
+ZPL_IMPL_INLINE zpl_u64 zpl_time_win32_to_unix(zpl_u64 ms) {
     return ms - ZPL__UNIX_TO_WIN32_EPOCH;
 }
 
-ZPL_IMPL_INLINE zpl_u64 zpl_unix_to_win32_epoch(zpl_u64 ms) {
+ZPL_IMPL_INLINE zpl_u64 zpl_time_unix_to_win32(zpl_u64 ms) {
     return ms + ZPL__UNIX_TO_WIN32_EPOCH;
 }
 
 ZPL_IMPL_INLINE void zpl_sleep(zpl_f32 s) {
     zpl_sleep_ms((zpl_u32)(s * 1000));
+}
+
+ZPL_IMPL_INLINE zpl_f64 zpl_time_now() {
+    return zpl_time_rel();
+}
+
+ZPL_IMPL_INLINE zpl_f64 zpl_utc_time_now() {
+    return zpl_time_utc();
 }
 
 ZPL_END_C_DECLS

--- a/code/header/core/time.h
+++ b/code/header/core/time.h
@@ -30,6 +30,12 @@ ZPL_DEF zpl_f64 zpl_utc_time_now(void);
 //! Return time since 1601-01-01 UTC.
 ZPL_DEF zpl_u64 zpl_utc_time_now_ms(void);
 
+//! Return local system time since 1601-01-01
+ZPL_DEF zpl_u64 zpl_local_time_now_ms(void);
+
+//! Return local system time in seconds since 1601-01-01
+ZPL_DEF zpl_f64 zpl_local_time_now(void);
+
 //! Convert Win32 epoch (1601-01-01 UTC) to UNIX (1970-01-01 UTC)
 ZPL_DEF_INLINE zpl_u64 zpl_win32_to_unix_epoch(zpl_u64 ms);
 
@@ -40,6 +46,22 @@ ZPL_DEF_INLINE zpl_u64 zpl_unix_to_win32_epoch(zpl_u64 ms);
 ZPL_DEF void zpl_sleep_ms(zpl_u32 ms);
 
 //! Sleep for specified number of seconds.
-ZPL_DEF void zpl_sleep(zpl_f32 s);
+ZPL_DEF_INLINE void zpl_sleep(zpl_f32 s);
+
+#ifndef ZPL__UNIX_TO_WIN32_EPOCH
+#define ZPL__UNIX_TO_WIN32_EPOCH 11644473600000ull
+#endif
+
+ZPL_IMPL_INLINE zpl_u64 zpl_win32_to_unix_epoch(zpl_u64 ms) {
+    return ms - ZPL__UNIX_TO_WIN32_EPOCH;
+}
+
+ZPL_IMPL_INLINE zpl_u64 zpl_unix_to_win32_epoch(zpl_u64 ms) {
+    return ms + ZPL__UNIX_TO_WIN32_EPOCH;
+}
+
+ZPL_IMPL_INLINE void zpl_sleep(zpl_f32 s) {
+    zpl_sleep_ms((zpl_u32)(s * 1000));
+}
 
 ZPL_END_C_DECLS

--- a/code/header/core/time.h
+++ b/code/header/core/time.h
@@ -18,13 +18,28 @@ ZPL_BEGIN_C_DECLS
 //! Return CPU timestamp.
 ZPL_DEF zpl_u64 zpl_rdtsc(void);
 
-//! Return relative time since the application start.
+//! Return relative time (in seconds) since the application start.
 ZPL_DEF zpl_f64 zpl_time_now(void);
 
-//! Return time since 1601-01-01 UTC.
+//! Return relative time since the application start.
+ZPL_DEF zpl_u64 zpl_time_now_ms(void);
+
+//! Return time (in seconds) since 1601-01-01 UTC.
 ZPL_DEF zpl_f64 zpl_utc_time_now(void);
+
+//! Return time since 1601-01-01 UTC.
+ZPL_DEF zpl_u64 zpl_utc_time_now_ms(void);
+
+//! Convert Win32 epoch (1601-01-01 UTC) to UNIX (1970-01-01 UTC)
+ZPL_DEF_INLINE zpl_u64 zpl_win32_to_unix_epoch(zpl_u64 ms);
+
+//! Convert UNIX (1970-01-01 UTC) to Win32 epoch (1601-01-01 UTC)
+ZPL_DEF_INLINE zpl_u64 zpl_unix_to_win32_epoch(zpl_u64 ms);
 
 //! Sleep for specified number of milliseconds.
 ZPL_DEF void zpl_sleep_ms(zpl_u32 ms);
+
+//! Sleep for specified number of seconds.
+ZPL_DEF void zpl_sleep(zpl_f32 s);
 
 ZPL_END_C_DECLS

--- a/code/source/core/random.c
+++ b/code/source/core/random.c
@@ -65,7 +65,7 @@ void zpl_random_init(zpl_random *r) {
     r->offsets[2] = 0;
     r->offsets[3] = 1;
 #endif
-    time = cast(zpl_u64)zpl_utc_time_now();
+    time = zpl_local_time_now_ms();
     r->offsets[4] = cast(zpl_u32)(time >> 32);
     r->offsets[5] = cast(zpl_u32)time;
     r->offsets[6] = zpl__get_noise_from_time();

--- a/code/source/core/random.c
+++ b/code/source/core/random.c
@@ -17,12 +17,12 @@ zpl_internal zpl_u32 zpl__get_noise_from_time(void) {
     zpl_f64 start, remaining, end, curr = 0;
     zpl_u64 interval = 100000ll;
 
-    start     = zpl_time_now();
+    start     = zpl_time_rel();
     remaining = (interval - cast(zpl_u64)(interval*start)%interval) / cast(zpl_f64)interval;
     end       = start + remaining;
 
     do {
-        curr = zpl_time_now();
+        curr = zpl_time_rel();
         accum += cast(zpl_u32)curr;
     } while (curr >= end);
     return accum;
@@ -65,7 +65,7 @@ void zpl_random_init(zpl_random *r) {
     r->offsets[2] = 0;
     r->offsets[3] = 1;
 #endif
-    time = zpl_local_time_now_ms();
+    time = zpl_time_tz_ms();
     r->offsets[4] = cast(zpl_u32)(time >> 32);
     r->offsets[5] = cast(zpl_u32)time;
     r->offsets[6] = zpl__get_noise_from_time();

--- a/code/source/core/time.c
+++ b/code/source/core/time.c
@@ -99,7 +99,7 @@ ZPL_BEGIN_C_DECLS
 
 #if defined(ZPL_SYSTEM_WINDOWS) || defined(ZPL_SYSTEM_CYGWIN)
 
-    zpl_u64 zpl_time_now_ms(void) {
+    zpl_u64 zpl_time_rel_ms(void) {
         zpl_local_persist LARGE_INTEGER win32_perf_count_freq = { 0 };
         zpl_u64 result;
         LARGE_INTEGER counter;
@@ -116,7 +116,7 @@ ZPL_BEGIN_C_DECLS
         return result;
     }
 
-    zpl_u64 zpl_utc_time_now_ms(void) {
+    zpl_u64 zpl_time_utc_ms(void) {
         FILETIME ft;
         ULARGE_INTEGER li;
 
@@ -127,7 +127,7 @@ ZPL_BEGIN_C_DECLS
         return li.QuadPart / 1000;
     }
 
-    zpl_u64 zpl_local_time_now_ms(void) {
+    zpl_u64 zpl_time_tz_ms(void) {
         FILETIME ft;
         SYSTEMTIME st, lst;
         ULARGE_INTEGER li;
@@ -156,7 +156,7 @@ ZPL_BEGIN_C_DECLS
         }
     #endif
 
-    zpl_u64 zpl_time_now_ms(void) {
+    zpl_u64 zpl_time_rel_ms(void) {
     #if defined(ZPL_SYSTEM_OSX)
         zpl_u64 result;
 
@@ -185,7 +185,7 @@ ZPL_BEGIN_C_DECLS
     #endif
     }
 
-    zpl_u64 zpl_utc_time_now_ms(void) {
+    zpl_u64 zpl_time_utc_ms(void) {
         struct timespec t;
     #if defined(ZPL_SYSTEM_OSX)
         clock_serv_t cclock;
@@ -207,9 +207,9 @@ ZPL_BEGIN_C_DECLS
         nanosleep(&req, &rem);
     }
 
-    zpl_u64 zpl_local_time_now_ms(void) {
+    zpl_u64 zpl_time_tz_ms(void) {
         struct tm t;
-        zpl_u64 result = zpl_utc_time_now_ms() - ZPL__UNIX_TO_WIN32_EPOCH;
+        zpl_u64 result = zpl_time_utc_ms() - ZPL__UNIX_TO_WIN32_EPOCH;
         zpl_u16 ms = result % 1000;
         result *= 1e-3;
         localtime_r((const time_t*)&result, &t);
@@ -218,16 +218,16 @@ ZPL_BEGIN_C_DECLS
     }
 #endif
 
-zpl_f64 zpl_time_now(void) {
-    return (zpl_f64)(zpl_time_now_ms() * 1e-3);
+zpl_f64 zpl_time_rel(void) {
+    return (zpl_f64)(zpl_time_rel_ms() * 1e-3);
 }
 
-zpl_f64 zpl_utc_time_now(void) {
-    return (zpl_f64)(zpl_utc_time_now_ms() * 1e-3);
+zpl_f64 zpl_time_utc(void) {
+    return (zpl_f64)(zpl_time_utc_ms() * 1e-3);
 }
 
-zpl_f64 zpl_local_time_now(void) {
-    return (zpl_f64)(zpl_local_time_now_ms() * 1e-3);
+zpl_f64 zpl_time_tz(void) {
+    return (zpl_f64)(zpl_time_tz_ms() * 1e-3);
 }
 
 

--- a/code/source/timer.c
+++ b/code/source/timer.c
@@ -33,7 +33,7 @@ void zpl_timer_start(zpl_timer *t, zpl_f64 delay_start) {
 
     t->enabled = true;
     t->remaining_calls = t->initial_calls;
-    t->next_call_ts = zpl_time_now( ) + delay_start;
+    t->next_call_ts = zpl_time_rel( ) + delay_start;
 }
 
 void zpl_timer_stop(zpl_timer *t) {
@@ -45,7 +45,7 @@ void zpl_timer_stop(zpl_timer *t) {
 void zpl_timer_update(zpl_timer_pool pool) {
     ZPL_ASSERT(pool);
 
-    zpl_f64 now = zpl_time_now( );
+    zpl_f64 now = zpl_time_rel( );
 
     for (zpl_isize i = 0; i < zpl_array_count(pool); ++i) {
         zpl_timer *t = pool + i;

--- a/code/tests/cases/time.h
+++ b/code/tests/cases/time.h
@@ -1,0 +1,29 @@
+#ifdef ZPL_EDITOR
+    #include <zpl.h>
+    #include "unit.h"
+#endif
+
+#define __WIN32_TIMESTAMP_REFERENCE 13253813593098ull
+#define __UNIX_TIMESTAMP_REFERENCE 1609339993098ull
+
+MODULE(time, {
+    IT("provides a relative time since the first call with 50ms delay", {
+        (void)zpl_time_now_ms();
+        zpl_sleep_ms(50);
+        zpl_u64 b = zpl_time_now_ms();
+        GREATER(b, 0);
+    });
+
+    IT("provides a UTC time since Win32 epoch", {
+        GREATER(zpl_utc_time_now_ms(), __WIN32_TIMESTAMP_REFERENCE);
+    });
+
+    IT("can convert Win32 to UNIX epoch", {
+        EQUALS(__WIN32_TIMESTAMP_REFERENCE, zpl_unix_to_win32_epoch(__UNIX_TIMESTAMP_REFERENCE));
+    });
+
+    IT("can convert UNIX to Win32 epoch", {
+        EQUALS(__UNIX_TIMESTAMP_REFERENCE, zpl_win32_to_unix_epoch(__WIN32_TIMESTAMP_REFERENCE));
+    });
+});
+

--- a/code/tests/cases/time.h
+++ b/code/tests/cases/time.h
@@ -8,22 +8,22 @@
 
 MODULE(time, {
     IT("provides a relative time since the first call with 50ms delay", {
-        (void)zpl_time_now_ms();
+        (void)zpl_time_rel_ms();
         zpl_sleep_ms(50);
-        zpl_u64 b = zpl_time_now_ms();
+        zpl_u64 b = zpl_time_rel_ms();
         GREATER(b, 0);
     });
 
     IT("provides a UTC time since Win32 epoch", {
-        GREATER(zpl_utc_time_now_ms(), __WIN32_TIMESTAMP_REFERENCE);
+        GREATER(zpl_time_utc_ms(), __WIN32_TIMESTAMP_REFERENCE);
     });
 
     IT("can convert Win32 to UNIX epoch", {
-        EQUALS(__WIN32_TIMESTAMP_REFERENCE, zpl_unix_to_win32_epoch(__UNIX_TIMESTAMP_REFERENCE));
+        EQUALS(__WIN32_TIMESTAMP_REFERENCE, zpl_time_unix_to_win32(__UNIX_TIMESTAMP_REFERENCE));
     });
 
     IT("can convert UNIX to Win32 epoch", {
-        EQUALS(__UNIX_TIMESTAMP_REFERENCE, zpl_win32_to_unix_epoch(__WIN32_TIMESTAMP_REFERENCE));
+        EQUALS(__UNIX_TIMESTAMP_REFERENCE, zpl_time_win32_to_unix(__WIN32_TIMESTAMP_REFERENCE));
     });
 });
 

--- a/code/tests/tester.c
+++ b/code/tests/tester.c
@@ -8,6 +8,7 @@
 #include "cases/json.h"
 #include "cases/alloc_pool.h"
 #include "cases/hashing.h"
+#include "cases/time.h"
 
 int main() {
     UNIT_CREATE("zpl");
@@ -15,6 +16,7 @@ int main() {
     UNIT_CASE(json5_parser);
     UNIT_CASE(alloc_pool);
     UNIT_CASE(hashing);
+    UNIT_CASE(time);
 
     return UNIT_RUN();
 }


### PR DESCRIPTION
Features:
- [x] Add zpl_u64 variants
- [x] Add conversion methods between Win32 and UNIX epoch
- [x] Add `zpl_sleep` seconds variant
- [x] Add `zpl_time_tz` and `zpl_time_tz_ms` based on current timezone (taking DST into account as well)
- [x] Deprecate old time methods