### PR TITLE
New array methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+12.2.0  - Add zpl_array_fill and zpl_array_appendv_at
 12.1.0  - Add rectangle partitioning
 12.0.1  - Optimize zpl_strlen
 12.0.0  - JSON API revamp + improvements

--- a/code/apps/examples/array_appendv.c
+++ b/code/apps/examples/array_appendv.c
@@ -13,7 +13,7 @@ void display_arr(zpl_i32 *arr) {
 }
 
 int main() {
-    zpl_i32 *arr;
+    zpl_i32 *arr = NULL;
     zpl_array_init(arr, zpl_heap());
     zpl_array_appendv(arr, nums, zpl_count_of(nums));
     display_arr(arr);

--- a/code/apps/examples/array_appendv.c
+++ b/code/apps/examples/array_appendv.c
@@ -23,5 +23,7 @@ int main() {
 
     zpl_array_fill(arr, 1, 6, 5);
     display_arr(arr);
+
+    zpl_array_free(arr);
     return 0;
 }

--- a/code/apps/examples/array_appendv.c
+++ b/code/apps/examples/array_appendv.c
@@ -1,0 +1,27 @@
+#define ZPL_IMPLEMENTATION
+#define ZPL_NANO
+#include <zpl.h>
+
+zpl_i32 nums[] = { 1,2,3,4,5 };
+zpl_i32 xtra[] = { 9,9,8 };
+
+void display_arr(zpl_i32 *arr) {
+    for (zpl_isize i = 0; i < zpl_array_count(arr); i++) {
+        zpl_printf("%d, ", arr[i]);
+    }
+    zpl_printf("%s", "\n");
+}
+
+int main() {
+    zpl_i32 *arr;
+    zpl_array_init(arr, zpl_heap());
+    zpl_array_appendv(arr, nums, zpl_count_of(nums));
+    display_arr(arr);
+
+    zpl_array_appendv_at(arr, xtra, zpl_count_of(xtra), 1);
+    display_arr(arr);
+
+    zpl_array_fill(arr, 1, 6, 5);
+    display_arr(arr);
+    return 0;
+}

--- a/code/header/essentials/collections/array.h
+++ b/code/header/essentials/collections/array.h
@@ -137,7 +137,7 @@ do {                                                                            
 #define zpl_array_append_at(x, item, ind)                                                                              \
 do {                                                                                                               \
     zpl_array_header *zpl__ah = ZPL_ARRAY_HEADER(x);                                                               \
-    if (ind == zpl__ah->count) { zpl_array_append(x, item); break; }                                               \
+    if (ind >= zpl__ah->count) { zpl_array_append(x, item); break; }                                               \
     if (zpl_array_capacity(x) < zpl_array_count(x) + 1) zpl_array_grow(x, 0);                                      \
     zpl_memmove(&(x)[ind + 1], (x + ind), zpl_size_of(x[0]) * (zpl__ah->count - ind));                             \
     x[ind] = item;                                                                                                 \
@@ -151,6 +151,25 @@ do {                                                                            
     if (zpl__ah->capacity < zpl__ah->count + (item_count)) zpl_array_grow(x, zpl__ah->count + (item_count));       \
     zpl_memcopy(&(x)[zpl__ah->count], (items), zpl_size_of((x)[0]) * (item_count));                                \
     zpl__ah->count += (item_count);                                                                                \
+} while (0)
+
+#define zpl_array_appendv_at(x, items, item_count, ind)                                                                        \
+do {                                                                                                               \
+    zpl_array_header *zpl__ah = ZPL_ARRAY_HEADER(x);                                                               \
+    if (ind >= zpl__ah->count) { zpl_array_appendv(x, items, item_count); break; }                                               \
+    ZPL_ASSERT(zpl_size_of((items)[0]) == zpl_size_of((x)[0]));                                                    \
+    if (zpl__ah->capacity < zpl__ah->count + (item_count)) zpl_array_grow(x, zpl__ah->count + (item_count));       \
+    zpl_memmove(x + ind + (item_count), x + ind, zpl_size_of((x)[0]) * zpl__ah->count);                                \
+    zpl_memcopy(&(x)[ind], (items), zpl_size_of((x)[0]) * (item_count));                                \
+    zpl__ah->count += (item_count);                                                                                \
+} while (0)
+
+#define zpl_array_fill(x, begin, end, value)                                                                        \
+do {                                                                                                               \
+    zpl_array_header *zpl__ah = ZPL_ARRAY_HEADER(x);                                                               \
+    ZPL_ASSERT((begin) >= 0 && (end) < zpl__ah->count);                                               \
+    ZPL_ASSERT(zpl_size_of(value) == zpl_size_of((x)[0]));                                                    \
+    for (zpl_isize i = (begin); i < (end); i++) { x[i] = value; }                                                  \
 } while (0)
 
 #define zpl_array_remove_at(x, index)                                                                                  \


### PR DESCRIPTION
Based on request, two new methods were implemented for the array module:

* `zpl_array_appendv_at(array, items, item_count, index)`
* `zpl_array_fill(array, begin_index, end_index, value)`

See `examples/array_appendv.c` for an example usage.