### PR TITLE
Register macroizing conflict on C++/MSVC compiler

### DIFF
--- a/code/header/essentials/types.h
+++ b/code/header/essentials/types.h
@@ -108,10 +108,6 @@ typedef zpl_i32 zpl_b32;
     #endif
 #endif
 
-#if __cplusplus > 199711L
-#define register      // Deprecated in C++11.
-#endif  // #if __cplusplus > 199711L
-
 #ifndef ZPL_U8_MIN
     #define ZPL_U8_MIN 0u
     #define ZPL_U8_MAX 0xffu

--- a/code/source/math.c
+++ b/code/source/math.c
@@ -1335,7 +1335,7 @@ void zpl_frustum_create(zpl_frustum* out, zpl_mat4* camera, zpl_mat4* proj) {
 
     zpl_mat4_mul(&pv, camera, proj);
 
-    register zpl_plane* fp = 0;
+    zpl_plane* fp = 0;
     zpl_f32 rmag;
 
     fp = &out->x1;


### PR DESCRIPTION
On MSVC Visual Studio 2019, it generates an error saying that the C++ standard forbids macroizing the register keyword:

xkeycheck.h(341, 1): [C1189] #error:  The C++ Standard Library forbids macroizing the keyword "register". Enable warning C4005 to find the forbidden define.

Since it is only used once anyway, I would suggest removing it :)