### PR TITLE
Critical section issues when ZPL_NO_WINDOWS_H is defined

### DIFF
--- a/code/header/threading/mutex.h
+++ b/code/header/threading/mutex.h
@@ -5,7 +5,7 @@ ZPL_BEGIN_C_DECLS
 
 typedef struct zpl_mutex {
 #if defined(ZPL_SYSTEM_WINDOWS)
-    CRITICAL_SECTION win32_critical_section;
+    zpl_u64 win32_critical_section[sizeof(zpl_usize) / 2 + 1];
 #else
     pthread_mutex_t pthread_mutex;
 #endif

--- a/code/source/threading/mutex.c
+++ b/code/source/threading/mutex.c
@@ -5,7 +5,7 @@ ZPL_BEGIN_C_DECLS
 
 void zpl_mutex_init(zpl_mutex *m) {
 #    if defined(ZPL_SYSTEM_WINDOWS)
-        InitializeCriticalSection(&m->win32_critical_section);
+        InitializeCriticalSection((CRITICAL_SECTION*)m->win32_critical_section);
 #    else
         pthread_mutex_init(&m->pthread_mutex, NULL);
 #    endif
@@ -13,7 +13,7 @@ void zpl_mutex_init(zpl_mutex *m) {
 
 void zpl_mutex_destroy(zpl_mutex *m) {
 #    if defined(ZPL_SYSTEM_WINDOWS)
-        DeleteCriticalSection(&m->win32_critical_section);
+        DeleteCriticalSection((CRITICAL_SECTION*)m->win32_critical_section);
 #    else
         pthread_mutex_destroy(&m->pthread_mutex);
 #    endif
@@ -21,7 +21,7 @@ void zpl_mutex_destroy(zpl_mutex *m) {
 
 void zpl_mutex_lock(zpl_mutex *m) {
 #    if defined(ZPL_SYSTEM_WINDOWS)
-        EnterCriticalSection(&m->win32_critical_section);
+        EnterCriticalSection((CRITICAL_SECTION*)m->win32_critical_section);
 #    else
         pthread_mutex_lock(&m->pthread_mutex);
 #    endif
@@ -29,7 +29,7 @@ void zpl_mutex_lock(zpl_mutex *m) {
 
 zpl_b32 zpl_mutex_try_lock(zpl_mutex *m) {
 #    if defined(ZPL_SYSTEM_WINDOWS)
-        return TryEnterCriticalSection(&m->win32_critical_section);
+        return TryEnterCriticalSection((CRITICAL_SECTION*)m->win32_critical_section);
 #    else
         return pthread_mutex_trylock(&m->pthread_mutex);
 #    endif
@@ -37,7 +37,7 @@ zpl_b32 zpl_mutex_try_lock(zpl_mutex *m) {
 
 void zpl_mutex_unlock(zpl_mutex *m) {
 #    if defined(ZPL_SYSTEM_WINDOWS)
-        LeaveCriticalSection(&m->win32_critical_section);
+        LeaveCriticalSection((CRITICAL_SECTION*)m->win32_critical_section);
 #    else
         pthread_mutex_unlock(&m->pthread_mutex);
 #    endif


### PR DESCRIPTION
Hey, 
I noticed that when you define ZPL_NO_WINDOWS_H (to bypass including Windows.h), there is an error where it can't find CRITICAL_SECTION struct from win32. I replaced it with a static zpl_u64 array (u64 so thats its aligned to 8-byte). So you can include zpl.h without including Windows.h, you just need to include it where you define ZPL_IMPL.