### PR TITLE
fix: zpl_str_skip_literal reading before start of string

### DIFF
--- a/code/header/core/string.h
+++ b/code/header/core/string.h
@@ -398,6 +398,10 @@ ZPL_IMPL_INLINE char const *zpl_str_skip_any(char const *str, char const*char_li
 }
 
 ZPL_IMPL_INLINE char const *zpl_str_skip_literal(char const *str, char c) {
+    if (*str == '\0' || *str == c)
+        return str;
+    str++;
+
     while ((*str && *str != c) || (*str == c && *(str-1) == '\\')) { ++str; }
     return str;
 }


### PR DESCRIPTION
- `zpl_str_skip_literal` has a bug where it will read before the start of the input string, causing to not catch unescaped character at the start of the string if it reads a "\\" in the memory before the string.
- fixed by adding an extra check at the start of the function to exit early if the unescaped character is found.

Example: 
```c
int main(void)
{
    // 'zpl_str_skip_literal' expected to keep skipping until reaching an unescaped 's'
    const char* myString = "\\skipmesbutnotme";
    const char* mySubString = myString+1;

    // "\skipmesbutnotme" expected to stop at the unescaped 's' in the middle, "sbutnotme"
    const char* myStringSkipped = zpl_str_skip_literal(myString, 's');
    puts(myString);
    puts(myStringSkipped);
    
    printf("\n");

    // "skipmesbutnotme" expected to stop at the start, "skipmesbutnotme"
    const char* mySubStringSkipped = zpl_str_skip_literal(mySubString, 's');
    puts(mySubString);
    puts(mySubStringSkipped);
}
```
Example output without fix:
```
\skipmesbutnotme
sbutnotme

skipmesbutnotme
sbutnotme
```
Example output  after fix:
```
\skipmesbutnotme
sbutnotme

skipmesbutnotme
skipmesbutnotme
```