### PR TITLE
Support for ZPL_JSON_INDENT_STYLE_COMPACT

### DIFF
--- a/code/header/parsers/json.h
+++ b/code/header/parsers/json.h
@@ -15,6 +15,10 @@ typedef enum zpl_json_error {
     ZPL_JSON_ERROR_OUT_OF_MEMORY,
 } zpl_json_error;
 
+typedef enum zpl_json_indent_style {
+    ZPL_JSON_INDENT_STYLE_COMPACT = -1000,
+} zpl_json_indent_style;
+
 typedef zpl_adt_node zpl_json_object;
 
 ZPL_DEF zpl_u8 zpl_json_parse(zpl_json_object *root, char *text, zpl_allocator allocator);

--- a/code/source/parsers/json.c
+++ b/code/source/parsers/json.c
@@ -79,6 +79,8 @@ item.nodes[i].parent = zpl_array_end(x);\
 
 static ZPL_ALWAYS_INLINE zpl_b32 zpl__json_is_assign_char(char c) { return !!zpl_strchr(":=|", c); }
 static ZPL_ALWAYS_INLINE zpl_b32 zpl__json_is_delim_char(char c) { return !!zpl_strchr(",|\n", c); }
+static ZPL_ALWAYS_INLINE const char *zpl__json_string_space(zpl_isize indent) { return indent == ZPL_JSON_INDENT_STYLE_COMPACT ? "" : " "; }
+static ZPL_ALWAYS_INLINE const char *zpl__json_string_eol(zpl_isize indent) { return indent == ZPL_JSON_INDENT_STYLE_COMPACT ? "" : "\n"; }
 ZPL_DEF_INLINE zpl_b32 zpl__json_validate_name(char const *str, char *err);
 
 #define jx(x) !zpl_char_is_hex_digit(str[x])
@@ -375,7 +377,7 @@ zpl_b8 zpl_json_write(zpl_file *f, zpl_adt_node *o, zpl_isize indent) {
 #else
     if (1)
 #endif
-    zpl__json_fprintf(f, "%c\n", o->type == ZPL_ADT_TYPE_OBJECT ? '{' : '[');
+    zpl__json_fprintf(f, "%c%s", o->type == ZPL_ADT_TYPE_OBJECT ? '{' : '[', zpl__json_string_eol(indent));
     else
     {
         indent -= 4;
@@ -397,7 +399,7 @@ zpl_b8 zpl_json_write(zpl_file *f, zpl_adt_node *o, zpl_isize indent) {
 #ifndef ZPL_PARSER_DISABLE_ANALYSIS
         if (!o->cfg_mode)
 #endif
-        zpl__json_fprintf(f, "%c\n", o->type == ZPL_ADT_TYPE_OBJECT ? '}' : ']');
+        zpl__json_fprintf(f, "%c%s", o->type == ZPL_ADT_TYPE_OBJECT ? '}' : ']', zpl__json_string_eol(indent));
     }
 
     return true;
@@ -405,7 +407,7 @@ zpl_b8 zpl_json_write(zpl_file *f, zpl_adt_node *o, zpl_isize indent) {
 
 zpl_b8 zpl__json_write_value(zpl_file *f, zpl_adt_node *o, zpl_adt_node *t, zpl_isize indent, zpl_b32 is_inline, zpl_b32 is_last) {
     zpl_adt_node *node = o;
-    indent += 4;
+    if (indent != ZPL_JSON_INDENT_STYLE_COMPACT) indent += 4;
 
     if (!is_inline) {
         zpl___ind(indent);
@@ -427,18 +429,18 @@ zpl_b8 zpl__json_write_value(zpl_file *f, zpl_adt_node *o, zpl_adt_node *t, zpl_
             }
 
             if (o->assign_style == ZPL_ADT_ASSIGN_STYLE_COLON)
-                zpl__json_fprintf(f, ": ");
+                zpl__json_fprintf(f, ":%s", zpl__json_string_space(indent));
             else {
                 zpl___ind(zpl_max(o->assign_line_width, 1));
 
                 if (o->assign_style == ZPL_ADT_ASSIGN_STYLE_EQUALS)
-                    zpl__json_fprintf(f, "= ");
+                    zpl__json_fprintf(f, "=%s", zpl__json_string_space(indent));
                 else if (o->assign_style == ZPL_ADT_ASSIGN_STYLE_LINE) {
-                    zpl__json_fprintf(f, "| ");
+                    zpl__json_fprintf(f, "|%s", zpl__json_string_space(indent));
                 }
             }
 #else
-            zpl__json_fprintf(f, "\"%s\": ", node->name);
+            zpl__json_fprintf(f, "\"%s\":%s", node->name, zpl__json_string_space(indent));
 #endif
         }
     }
@@ -461,7 +463,7 @@ zpl_b8 zpl__json_write_value(zpl_file *f, zpl_adt_node *o, zpl_adt_node *t, zpl_
             zpl_isize elemn = zpl_array_count(node->nodes);
             for (int j = 0; j < elemn; ++j) {
                 zpl_isize ind = ((node->nodes + j)->type == ZPL_ADT_TYPE_OBJECT || (node->nodes + j)->type == ZPL_ADT_TYPE_ARRAY) ? 0 : -4;
-                if (!zpl__json_write_value(f, node->nodes + j, o, ind, true, true)) return false;
+                if (!zpl__json_write_value(f, node->nodes + j, o, indent == ZPL_JSON_INDENT_STYLE_COMPACT ? indent : ind, true, true)) return false;
 
                 if (j < elemn - 1) { zpl__json_fprintf(f, ", "); }
             }
@@ -482,24 +484,24 @@ zpl_b8 zpl__json_write_value(zpl_file *f, zpl_adt_node *o, zpl_adt_node *t, zpl_
 #ifndef ZPL_PARSER_DISABLE_ANALYSIS
         if (o->delim_style != ZPL_ADT_DELIM_STYLE_COMMA) {
             if (o->delim_style == ZPL_ADT_DELIM_STYLE_NEWLINE)
-                zpl__json_fprintf(f, "\n");
+                zpl__json_fprintf(f, "%s", zpl__json_string_eol(indent));
             else if (o->delim_style == ZPL_ADT_DELIM_STYLE_LINE) {
                 zpl___ind(o->delim_line_width);
-                zpl__json_fprintf(f, "|\n");
+                zpl__json_fprintf(f, "|%s", zpl__json_string_eol(indent));
             }
         }
         else {
             if (!is_last) {
-                zpl__json_fprintf(f, ",\n");
+                zpl__json_fprintf(f, ",%s", zpl__json_string_eol(indent));
             } else {
-                zpl__json_fprintf(f, "\n");
+                zpl__json_fprintf(f, "%s", zpl__json_string_eol(indent));
             }
         }
 #else
         if (!is_last) {
-            zpl__json_fprintf(f, ",\n");
+            zpl__json_fprintf(f, ",%s", zpl__json_string_eol(indent));
         } else {
-            zpl__json_fprintf(f, "\n");
+            zpl__json_fprintf(f, "%s", zpl__json_string_eol(indent));
         }
 #endif
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zpl.c",
-  "version": "19.4.0",
+  "version": "19.3.1",
   "homepage": "https://github.com/zpl-c/zpl#readme",
   "description": "Single-file header-only C and C++ helper library.",
   "author": "Dominik Madarasz <zaklaus@outlook.com> (http://madaraszd.net/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zpl.c",
-  "version": "19.3.1",
+  "version": "19.4.0",
   "homepage": "https://github.com/zpl-c/zpl#readme",
   "description": "Single-file header-only C and C++ helper library.",
   "author": "Dominik Madarasz <zaklaus@outlook.com> (http://madaraszd.net/)",


### PR DESCRIPTION
I've had this in my local copy for a while and kept forgetting to contribute back.
We need to be able to generate "compact" JSON, so no extra newlines or spaces. It seemed nicer to generate it correctly, rather than strip newlines and spaces after.

Let me know if you feel I should tidy any thing up.